### PR TITLE
set authentication to CDI, skip Jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ kumuluzee:
       admin: role_admin
 ```
 
+You may also disable Jetty servlet security, which is enabled by default, by setting key `kumuluzee.security.disable-jetty-auth` to `true`.
+
 ## Changelog
 
 Recent changes can be viewed on Github on the [Releases Page](https://github.com/kumuluz/kumuluzee-security/releases)

--- a/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
+++ b/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
@@ -70,12 +70,15 @@ public class KeycloakSecurityConfigurationUtilImpl implements SecurityConfigurat
         if (webAppContextHandler != null) {
             ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
             constraintSecurityHandler.setAuthenticator(new KeycloakJettyAuthenticator());
-            
-            // handle this in CDI security, not with Jetty
-            /*Set<String> roles = new HashSet<>(declaredRoles);
-            constraintSecurityHandler.setRoles(roles);
-            List<ConstraintMapping> constraintMappings = toConstraintMappings(constraints);
-            constraintSecurityHandler.setConstraintMappings(constraintMappings);*/
+
+            // When using CDI security, Jetty security must be disabled, otherwise it causes problems
+            boolean jettyAuthDisabled = ConfigurationUtil.getInstance().getBoolean("kumuluzee.security.disable-jetty-auth").orElse(false);
+            if (!jettyAuthDisabled) {
+                Set<String> roles = new HashSet<>(declaredRoles);
+                constraintSecurityHandler.setRoles(roles);
+                List<ConstraintMapping> constraintMappings = toConstraintMappings(constraints);
+                constraintSecurityHandler.setConstraintMappings(constraintMappings);
+            }
 
             webAppContextHandler.setSecurityHandler(constraintSecurityHandler);
         }

--- a/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
+++ b/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
@@ -70,11 +70,12 @@ public class KeycloakSecurityConfigurationUtilImpl implements SecurityConfigurat
         if (webAppContextHandler != null) {
             ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
             constraintSecurityHandler.setAuthenticator(new KeycloakJettyAuthenticator());
-
-            Set<String> roles = new HashSet<>(declaredRoles);
+            
+            // handle this in CDI security, not with Jetty
+            /*Set<String> roles = new HashSet<>(declaredRoles);
             constraintSecurityHandler.setRoles(roles);
             List<ConstraintMapping> constraintMappings = toConstraintMappings(constraints);
-            constraintSecurityHandler.setConstraintMappings(constraintMappings);
+            constraintSecurityHandler.setConstraintMappings(constraintMappings);*/
 
             webAppContextHandler.setSecurityHandler(constraintSecurityHandler);
         }

--- a/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
+++ b/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
@@ -71,7 +71,7 @@ public class KeycloakSecurityConfigurationUtilImpl implements SecurityConfigurat
             ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
             constraintSecurityHandler.setAuthenticator(new KeycloakJettyAuthenticator());
 
-            // When using CDI security, Jetty security must be disabled, otherwise it causes problems
+            // Allows to disable security in jetty servlet
             boolean jettyAuthDisabled = ConfigurationUtil.getInstance().getBoolean("kumuluzee.security.disable-jetty-auth").orElse(false);
             if (!jettyAuthDisabled) {
                 Set<String> roles = new HashSet<>(declaredRoles);


### PR DESCRIPTION
Jetty was authorizing users before Kumuluz Security.
This caused that user with proper role was authenticated 2 times (Jetty and then Kumuluz).
In case user lacked required role, Jetty denied the request, before Kumuluz was able to filter it and therefore some headers weren't properly set. (in combination with CORS, the CORS headers weren't set due to that)