### PR TITLE
Add a new property to specify custom config resolver class for keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ kumuluzee:
 
 You may also disable Jetty servlet security, which is enabled by default, by setting key `kumuluzee.security.disable-jetty-auth` to `true`.
 
+You can set a custom config resolver class (see [here](https://www.keycloak.org/docs/latest/securing_apps/index.html#config_external_adapter)) to be able to tweak keycloak configuration at runtime for each request (for multitenant purpose). Note that this class must implements `org.keycloak.adapters.KeycloakConfigResolver`.
+
+Example custom config resolver configuration:
+```yaml
+kumuluzee:
+  security:
+    keycloak:
+      config-resolver: foo.bar.MyKeycloakConfigResolver
+```
+
 ## Changelog
 
 Recent changes can be viewed on Github on the [Releases Page](https://github.com/kumuluz/kumuluzee-security/releases)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ kumuluzee:
 
 You may also disable Jetty servlet security, which is enabled by default, by setting key `kumuluzee.security.disable-jetty-auth` to `true`.
 
-You can set a custom config resolver class (see [here](https://www.keycloak.org/docs/latest/securing_apps/index.html#config_external_adapter)) to be able to tweak keycloak configuration at runtime for each request (for multitenant purpose). Note that this class must implements `org.keycloak.adapters.KeycloakConfigResolver`.
+You can set a custom config resolver class (see [here](https://www.keycloak.org/docs/latest/securing_apps/index.html#config_external_adapter)) to be able to tweak Keycloak configuration at runtime for each request (for multitenant or purposes). Note that this class must implement `org.keycloak.adapters.KeycloakConfigResolver`.
 
 Example custom config resolver configuration:
 ```yaml

--- a/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
+++ b/keycloak/src/main/java/com/kumuluz/ee/security/KeycloakSecurityConfigurationUtilImpl.java
@@ -67,12 +67,14 @@ public class KeycloakSecurityConfigurationUtilImpl implements SecurityConfigurat
             webAppContextHandler = (WebAppContext) webAppContext.getContextHandler();
         }
 
+        final ConfigurationUtil configurationUtil = ConfigurationUtil.getInstance();
+
         if (webAppContextHandler != null) {
             ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
             constraintSecurityHandler.setAuthenticator(new KeycloakJettyAuthenticator());
 
             // Allows to disable security in jetty servlet
-            boolean jettyAuthDisabled = ConfigurationUtil.getInstance().getBoolean("kumuluzee.security.disable-jetty-auth").orElse(false);
+            boolean jettyAuthDisabled = configurationUtil.getBoolean("kumuluzee.security.disable-jetty-auth").orElse(false);
             if (!jettyAuthDisabled) {
                 Set<String> roles = new HashSet<>(declaredRoles);
                 constraintSecurityHandler.setRoles(roles);
@@ -85,6 +87,10 @@ public class KeycloakSecurityConfigurationUtilImpl implements SecurityConfigurat
 
         if (webAppContext != null) {
             webAppContext.setInitParameter("org.keycloak.json.adapterConfig", keycloakConfig);
+            Optional<String> configResolver = configurationUtil.get("kumuluzee.security.keycloak.config-resolver");
+            if (configResolver.isPresent()) {
+                webAppContext.setInitParameter("keycloak.config.resolver", configResolver.get());
+            }
         }
 
         this.roleMappings = roleMappings;


### PR DESCRIPTION
I added a new property in kumuluzee.security.keycloak configuration node to be able to specify a custom config resolver.

It's useful when dealing with multitenant architecture because you can tweak keycloak configuration for each request (for example, setting a specific realm).

I didn't see any test on this part so I didn't write any but I can write some tests if you prefer.

BTW, thanks for your work on Kumuluzee 👍 